### PR TITLE
Remove private data and update on hide/restore

### DIFF
--- a/src/Listener/GenerateSitemap.php
+++ b/src/Listener/GenerateSitemap.php
@@ -62,7 +62,7 @@ class GenerateSitemap
         }
 
         // Get all tags
-        if (class_exists('Tag')) {
+        if (class_exists(Tag::class)) {
             $tags = Tag::all();
 
             // Add tags
@@ -72,7 +72,7 @@ class GenerateSitemap
         }
 
         // Get all pages
-        if (class_exists('Page')) {
+        if (class_exists(Page::class)) {
             $pages = Page::all();
 
             //Add pages

--- a/src/Listener/GenerateSitemap.php
+++ b/src/Listener/GenerateSitemap.php
@@ -2,6 +2,7 @@
 
 namespace Terabin\Sitemap\Listener;
 
+use Flarum\Core\Guest;
 use Flarum\Event\DiscussionWasHidden;
 use Flarum\Event\DiscussionWasRestored;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -52,10 +53,10 @@ class GenerateSitemap
         $sitemap = new Sitemap($basePath.'/sitemap.xml');
 
         // Get all discussions
-        $discussions = Discussion::all();
+        $discussions = Discussion::whereVisibleTo(new Guest())->get();
 
         // Get all users
-        $users = User::all();
+        $users = User::whereVisibleTo(new Guest())->get();
 
         // Add home
         $sitemap->addItem($url, time(), Sitemap::DAILY, 0.9);
@@ -67,7 +68,7 @@ class GenerateSitemap
 
         // Get all tags
         if (class_exists(Tag::class)) {
-            $tags = Tag::all();
+            $tags = Tag::whereVisibleTo(new Guest())->get();
 
             // Add tags
             foreach ($tags as $tag) {

--- a/src/Listener/GenerateSitemap.php
+++ b/src/Listener/GenerateSitemap.php
@@ -2,6 +2,8 @@
 
 namespace Terabin\Sitemap\Listener;
 
+use Flarum\Event\DiscussionWasHidden;
+use Flarum\Event\DiscussionWasRestored;
 use Illuminate\Contracts\Events\Dispatcher;
 use Flarum\Event\DiscussionWasStarted;
 use Flarum\Event\DiscussionWasDeleted;
@@ -30,6 +32,8 @@ class GenerateSitemap
     public function subscribe(Dispatcher $events)
     {
         $events->listen(DiscussionWasStarted::class, [$this, 'UpdateSitemap']);
+        $events->listen(DiscussionWasRestored::class, [$this, 'UpdateSitemap']);
+        $events->listen(DiscussionWasHidden::class, [$this, 'UpdateSitemap']);
         $events->listen(DiscussionWasDeleted::class, [$this, 'UpdateSitemap']);
     }
 

--- a/src/Listener/GenerateSitemap.php
+++ b/src/Listener/GenerateSitemap.php
@@ -10,7 +10,6 @@ use Flarum\Core\User;
 use Flarum\Tags\Tag;
 use Flarum\Foundation\Application;
 use samdark\sitemap\Sitemap;
-use samdark\sitemap\Index;
 use Sijad\Pages\Page;
 
 class GenerateSitemap


### PR DESCRIPTION
Multiple fixes:

- Only show public data in the readme Fixes #5 
- Update sitemap when a discussion is hidden or restored
- Fix tags and page class test, no idea if/how this could have worked before :thinking: 